### PR TITLE
Add TypeScript client for MCP meta-analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Node artifacts
+node_modules/
+ts_client/node_modules/
+ts_client/dist/
+
+# R
+.Rhistory
+.RData
+.Rproj.user/

--- a/R/example_usage.R
+++ b/R/example_usage.R
@@ -1,0 +1,31 @@
+# Example usage of the MetaAnalysisClient R wrapper
+library(jsonlite)
+
+client <- MetaAnalysisClient$new("http://localhost:8080/mcp")
+
+# Initialize analysis
+client$initialize_meta_analysis(list(
+  study_type = "clinical_trial",
+  effect_measure = "OR",
+  analysis_model = "random"
+))
+
+# Upload study CSV data
+csv <- readLines("studies.csv")
+client$upload_study_data(list(
+  data_format = "csv",
+  data_content = paste(csv, collapse = "\n"),
+  validation_level = "basic"
+))
+
+client$perform_meta_analysis(list(
+  heterogeneity_test = TRUE,
+  publication_bias = TRUE,
+  sensitivity_analysis = FALSE
+))
+
+client$generate_forest_plot(list(plot_style = "classic"))
+client$assess_publication_bias(list(methods = c("funnel_plot")))
+report <- client$generate_report(list(format = "html"))
+
+print(report)

--- a/R/example_usage.R
+++ b/R/example_usage.R
@@ -11,6 +11,9 @@ client$initialize_meta_analysis(list(
 ))
 
 # Upload study CSV data
+if (!file.exists("studies.csv")) {
+  stop("Error: The file 'studies.csv' does not exist. Please provide the required file and try again.")
+}
 csv <- readLines("studies.csv")
 client$upload_study_data(list(
   data_format = "csv",

--- a/R/meta_analysis_client.R
+++ b/R/meta_analysis_client.R
@@ -1,0 +1,33 @@
+MetaAnalysisClient <- R6::R6Class(
+  "MetaAnalysisClient",
+  public = list(
+    base_url = NULL,
+    initialize = function(base_url) {
+      self$base_url <- sub("/$", "", base_url)
+    },
+    call_endpoint = function(name, params) {
+      url <- paste0(self$base_url, "/", name)
+      resp <- httr::POST(url, body = jsonlite::toJSON(params, auto_unbox = TRUE), encode = "json")
+      httr::stop_for_status(resp)
+      httr::content(resp, as = "parsed", type = "application/json")
+    },
+    initialize_meta_analysis = function(params) {
+      self$call_endpoint("initialize_meta_analysis", params)
+    },
+    upload_study_data = function(params) {
+      self$call_endpoint("upload_study_data", params)
+    },
+    perform_meta_analysis = function(params) {
+      self$call_endpoint("perform_meta_analysis", params)
+    },
+    generate_forest_plot = function(params) {
+      self$call_endpoint("generate_forest_plot", params)
+    },
+    assess_publication_bias = function(params) {
+      self$call_endpoint("assess_publication_bias", params)
+    },
+    generate_report = function(params) {
+      self$call_endpoint("generate_report", params)
+    }
+  )
+)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ run().catch(err => {
 });
 ```
 
-Run the script with `npx ts-node src/example.ts` after installing the dependencies.
+Run the script with `npm run example` after installing the dependencies.
 
 ## R Client
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ async function run() {
   await client.disconnect();
 }
 
-run().catch(console.error);
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
 ```
 
 Run the script with `npx ts-node src/example.ts` after installing the dependencies.

--- a/README.md
+++ b/README.md
@@ -56,3 +56,16 @@ run().catch(console.error);
 ```
 
 Run the script with `npx ts-node src/example.ts` after installing the dependencies.
+
+## R Client
+
+The `R` directory includes a small wrapper around the same MCP tools for R users.
+Install the `httr`, `jsonlite`, and `R6` packages, then source the script and run the example:
+
+```R
+source("R/meta_analysis_client.R")
+source("R/example_usage.R")
+```
+
+The example script connects to a running MCP server, uploads CSV study data,
+performs the analysis, and prints the generated report.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# MCP Meta-Analysis
+
+This repository contains design notes for a meta-analysis server and a simple TypeScript client.
+
+## TypeScript Client
+
+The `ts_client` directory provides a lightweight wrapper around the [modelcontextprotocol/typescript-sdk](https://github.com/modelcontextprotocol/typescript-sdk). It exposes convenience methods for each of the meta-analysis tools described in `meta_analysis_mcp_architecture.md`.
+
+### Installing Dependencies
+
+```
+cd ts_client
+npm install
+```
+
+### Example Usage
+
+The `src/example.ts` script demonstrates how to connect to a running MCP server and perform a full analysis.
+
+```ts
+import { MetaAnalysisClient } from './index.js';
+import { readFile } from 'fs/promises';
+
+async function run() {
+  const client = new MetaAnalysisClient('http://localhost:8080/mcp');
+  await client.connect();
+
+  await client.initializeMetaAnalysis({
+    study_type: 'clinical_trial',
+    effect_measure: 'OR',
+    analysis_model: 'random'
+  });
+
+  const csv = await readFile('studies.csv', 'utf-8');
+  await client.uploadStudyData({
+    data_format: 'csv',
+    data_content: csv,
+    validation_level: 'basic'
+  });
+
+  await client.performMetaAnalysis({
+    heterogeneity_test: true,
+    publication_bias: true,
+    sensitivity_analysis: false
+  });
+
+  await client.generateForestPlot({ plot_style: 'classic' });
+  await client.assessPublicationBias({ methods: ['funnel_plot'] });
+  const report = await client.generateReport({ format: 'html' });
+
+  console.log('Report:', report);
+  await client.disconnect();
+}
+
+run().catch(console.error);
+```
+
+Run the script with `npx ts-node src/example.ts` after installing the dependencies.

--- a/ts_client/package.json
+++ b/ts_client/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "meta-analysis-ts-client",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "example": "ts-node src/example.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "github:modelcontextprotocol/typescript-sdk"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.0"
+  }
+}

--- a/ts_client/package.json
+++ b/ts_client/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "example": "ts-node src/example.ts"
+    "example": "ts-node --esm src/example.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "github:modelcontextprotocol/typescript-sdk"

--- a/ts_client/src/example.ts
+++ b/ts_client/src/example.ts
@@ -11,6 +11,11 @@ async function run() {
     analysis_model: 'random'
   });
 
+  try {
+    await access('studies.csv');
+  } catch (err) {
+    throw new Error("The file 'studies.csv' does not exist. Please provide the file and try again.");
+  }
   const csv = await readFile('studies.csv', 'utf-8');
   await client.uploadStudyData({
     data_format: 'csv',

--- a/ts_client/src/example.ts
+++ b/ts_client/src/example.ts
@@ -1,0 +1,38 @@
+import { MetaAnalysisClient } from './index.js';
+import { readFile } from 'fs/promises';
+
+async function run() {
+  const client = new MetaAnalysisClient('http://localhost:8080/mcp');
+  await client.connect();
+
+  await client.initializeMetaAnalysis({
+    study_type: 'clinical_trial',
+    effect_measure: 'OR',
+    analysis_model: 'random'
+  });
+
+  const csv = await readFile('studies.csv', 'utf-8');
+  await client.uploadStudyData({
+    data_format: 'csv',
+    data_content: csv,
+    validation_level: 'basic'
+  });
+
+  await client.performMetaAnalysis({
+    heterogeneity_test: true,
+    publication_bias: true,
+    sensitivity_analysis: false
+  });
+
+  await client.generateForestPlot({ plot_style: 'classic' });
+  await client.assessPublicationBias({ methods: ['funnel_plot'] });
+  const report = await client.generateReport({ format: 'html' });
+
+  console.log('Report:', report);
+  await client.disconnect();
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/ts_client/src/index.ts
+++ b/ts_client/src/index.ts
@@ -1,0 +1,67 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+export class MetaAnalysisClient {
+  private client: Client;
+  private transport: StreamableHTTPClientTransport;
+
+  constructor(serverUrl: string) {
+    this.client = new Client({
+      name: 'meta-analysis-client',
+      version: '1.0.0'
+    });
+    this.transport = new StreamableHTTPClientTransport(new URL(serverUrl));
+  }
+
+  async connect(): Promise<void> {
+    await this.client.connect(this.transport);
+  }
+
+  async disconnect(): Promise<void> {
+    await this.transport.close();
+  }
+
+  async initializeMetaAnalysis(params: {
+    study_type: string;
+    effect_measure: string;
+    analysis_model: string;
+  }) {
+    return this.client.callTool({ name: 'initialize_meta_analysis', arguments: params });
+  }
+
+  async uploadStudyData(params: {
+    data_format: string;
+    data_content: string;
+    validation_level: string;
+  }) {
+    return this.client.callTool({ name: 'upload_study_data', arguments: params });
+  }
+
+  async performMetaAnalysis(params: {
+    heterogeneity_test?: boolean;
+    publication_bias?: boolean;
+    sensitivity_analysis?: boolean;
+  }) {
+    return this.client.callTool({ name: 'perform_meta_analysis', arguments: params });
+  }
+
+  async generateForestPlot(params: {
+    plot_style?: string;
+    confidence_level?: number;
+    custom_labels?: Record<string, string>;
+  }) {
+    return this.client.callTool({ name: 'generate_forest_plot', arguments: params });
+  }
+
+  async assessPublicationBias(params: { methods: string[] }) {
+    return this.client.callTool({ name: 'assess_publication_bias', arguments: params });
+  }
+
+  async generateReport(params: {
+    format: string;
+    include_code?: boolean;
+    journal_template?: string;
+  }) {
+    return this.client.callTool({ name: 'generate_report', arguments: params });
+  }
+}

--- a/ts_client/src/index.ts
+++ b/ts_client/src/index.ts
@@ -25,8 +25,7 @@ export class MetaAnalysisClient {
     study_type: string;
     effect_measure: string;
     analysis_model: string;
-  }) {
-    return this.client.callTool({ name: 'initialize_meta_analysis', arguments: params });
+  }): Promise<unknown> {
   }
 
   async uploadStudyData(params: {

--- a/ts_client/tsconfig.json
+++ b/ts_client/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add lightweight SDK-based TypeScript client in `ts_client/`
- document usage with an example in new README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ae9325af8832980adb6cbec68c983

## Summary by Sourcery

Introduce a new lightweight TypeScript client for MCP meta-analysis, including convenience methods, project configuration, usage documentation, and an example script

New Features:
- Add MetaAnalysisClient wrapper around @modelcontextprotocol/sdk with methods for connecting, initializing analyses, uploading study data, performing analyses, generating plots, assessing bias, and generating reports
- Include example.ts demonstrating an end-to-end workflow using the TypeScript client
- Document installation and usage in a new README, including example commands
- Configure the TypeScript client project with package.json and tsconfig.json