### PR TITLE
Implement MCP meta-analysis server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.RData
+*.png
+report.*
+.Rhistory
+__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,5 @@ COPY templates/ /meta_analysis/templates/
 
 EXPOSE 8080
 
+USER non-root
 CMD ["Rscript", "/meta_analysis/scripts/mcp_server.R"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM rocker/r-ver:4.3.0
+
+RUN apt-get update && apt-get install -y \
+    pandoc \
+    texlive-latex-base \
+    texlive-latex-recommended \
+    texlive-latex-extra \
+    imagemagick \
+    curl \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN R -e "install.packages(c('plumber','meta','metafor','ggplot2','forestplot','knitr','rmarkdown','dplyr','readxl','jsonlite'), repos='https://cran.rstudio.com/')"
+
+WORKDIR /meta_analysis
+
+COPY scripts/ /meta_analysis/scripts/
+COPY templates/ /meta_analysis/templates/
+
+EXPOSE 8080
+
+CMD ["Rscript", "/meta_analysis/scripts/mcp_server.R"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# MCP Meta-Analysis Server
+
+This repository provides a minimal implementation of an MCP (Model Context Protocol) server for performing meta-analysis in R.
+
+## Features
+- Upload study data (CSV/Excel)
+- Run a meta-analysis with the **meta** and **metafor** packages
+- Generate forest and funnel plots
+- Produce a simple HTML/PDF/Word report via R Markdown
+- REST API implemented with **plumber**
+- Containerized using Docker
+
+## Usage
+
+1. Build the Docker image
+
+```bash
+docker build -t mcp-meta .
+```
+
+2. Run the container
+
+```bash
+docker run -p 8080:8080 mcp-meta
+```
+
+3. Interact with the API using any HTTP client. Example endpoints:
+   - `POST /initialize_meta_analysis`
+   - `POST /upload_study_data`
+   - `POST /perform_meta_analysis`
+   - `POST /generate_forest_plot`
+   - `POST /assess_publication_bias`
+   - `POST /generate_report`
+
+Upload data should contain columns `study`, `effect_size`, and `se`.
+
+## Development
+
+The server code resides in `scripts/`. Templates for reports are in `templates/`.
+
+```bash
+Rscript scripts/mcp_server.R
+```
+
+This will start the API on port 8080.

--- a/scripts/mcp_server.R
+++ b/scripts/mcp_server.R
@@ -1,0 +1,3 @@
+library(plumber)
+pr <- plumb('scripts/plumber.R')
+pr$run(host='0.0.0.0', port=8080)

--- a/scripts/meta_analysis_utils.R
+++ b/scripts/meta_analysis_utils.R
@@ -81,10 +81,13 @@ generate_report <- function(format='html', include_code=FALSE){
                       html = 'html_document',
                       pdf = 'pdf_document',
                       word = 'word_document'),
-                    output_file = { 
-                      temp_file <- tempfile(fileext = paste0('.', format))
-                      temp_file
-                    },
+  temp_file <- tempfile(fileext = paste0('.', format))
+  rmarkdown::render('templates/meta_analysis_report.Rmd',
+                    output_format = switch(format,
+                      html = 'html_document',
+                      pdf = 'pdf_document',
+                      word = 'word_document'),
+                    output_file = temp_file,
                     params = list(result=res, include_code=include_code))
   temp_file
 }

--- a/scripts/meta_analysis_utils.R
+++ b/scripts/meta_analysis_utils.R
@@ -44,10 +44,11 @@ perform_analysis <- function(heterogeneity_test=TRUE, publication_bias=TRUE, sen
 # Generate forest plot
 generate_forest_plot <- function(plot_style='classic', confidence_level=0.95){
   res <- get('.current_result', envir=.GlobalEnv)
-  png('forest_plot.png', width=800, height=600)
+  temp_file <- tempfile(pattern = "forest_plot", fileext = ".png")
+  png(temp_file, width=800, height=600)
   forest(res, comb.fixed=FALSE, comb.random=TRUE, digits=2)
   dev.off()
-  'forest_plot.png'
+  temp_file
 }
 
 # Assess publication bias with funnel plot

--- a/scripts/meta_analysis_utils.R
+++ b/scripts/meta_analysis_utils.R
@@ -17,7 +17,10 @@ validate_data <- function(path, format){
   if(length(missing_cols) > 0){
     stop(paste('Missing columns:', paste(missing_cols, collapse=', ')))
   }
-  assign('.current_data', data, envir = .GlobalEnv)
+  if (!exists("meta_analysis_env", envir = .GlobalEnv)) {
+    assign("meta_analysis_env", new.env(parent = emptyenv()), envir = .GlobalEnv)
+  }
+  assign('.current_data', data, envir = get("meta_analysis_env", envir = .GlobalEnv))
   data
 }
 

--- a/scripts/meta_analysis_utils.R
+++ b/scripts/meta_analysis_utils.R
@@ -25,9 +25,9 @@ validate_data <- function(path, format){
 }
 
 # Perform meta-analysis using random/fixed automatically
-perform_analysis <- function(heterogeneity_test=TRUE, publication_bias=TRUE, sensitivity_analysis=FALSE){
+perform_analysis <- function(heterogeneity_test=TRUE, publication_bias=TRUE, sensitivity_analysis=FALSE, effect_measure='SMD'){
   data <- get('.current_data', envir=.GlobalEnv)
-  m <- metagen(TE=data$effect_size, seTE=data$se, studlab=data$study, sm='SMD', method.tau='DL')
+  m <- metagen(TE=data$effect_size, seTE=data$se, studlab=data$study, sm=effect_measure, method.tau='DL')
   if(heterogeneity_test){
     hetero <- list(Q = m$Q, df = m$df.Q, p = m$pval.Q, I2 = m$I2)
   } else {

--- a/scripts/meta_analysis_utils.R
+++ b/scripts/meta_analysis_utils.R
@@ -55,10 +55,11 @@ assess_publication_bias <- function(methods=c('funnel_plot','egger_test')){
   res <- get('.current_result', envir=.GlobalEnv)
   out <- list()
   if('funnel_plot' %in% methods){
-    png('funnel_plot.png', width=800, height=600)
+    plot_file <- tempfile(pattern = "funnel_plot_", fileext = ".png")
+    png(plot_file, width=800, height=600)
     funnel(res)
     dev.off()
-    out$funnel_plot <- 'funnel_plot.png'
+    out$funnel_plot <- plot_file
   }
   if('egger_test' %in% methods){
     out$egger <- tryCatch(ranktest(res), error=function(e) NA)

--- a/scripts/meta_analysis_utils.R
+++ b/scripts/meta_analysis_utils.R
@@ -1,0 +1,80 @@
+library(meta)
+library(metafor)
+library(jsonlite)
+
+# Global variable to store uploaded data
+.current_data <- NULL
+
+# Validate uploaded data
+validate_data <- function(path, format){
+  if(format == 'excel'){
+    data <- readxl::read_excel(path)
+  } else {
+    data <- read.csv(path)
+  }
+  required <- c('study', 'effect_size', 'se')
+  missing_cols <- setdiff(required, names(data))
+  if(length(missing_cols) > 0){
+    stop(paste('Missing columns:', paste(missing_cols, collapse=', ')))
+  }
+  assign('.current_data', data, envir = .GlobalEnv)
+  data
+}
+
+# Perform meta-analysis using random/fixed automatically
+perform_analysis <- function(heterogeneity_test=TRUE, publication_bias=TRUE, sensitivity_analysis=FALSE){
+  data <- get('.current_data', envir=.GlobalEnv)
+  m <- metagen(TE=data$effect_size, seTE=data$se, studlab=data$study, sm='SMD', method.tau='DL')
+  if(heterogeneity_test){
+    hetero <- list(Q = m$Q, df = m$df.Q, p = m$pval.Q, I2 = m$I2)
+  } else {
+    hetero <- NULL
+  }
+  if(publication_bias){
+    pb <- tryCatch({
+      metabias(m)
+    }, error=function(e) NA)
+  } else {
+    pb <- NULL
+  }
+  assign('.current_result', m, envir=.GlobalEnv)
+  list(summary=summary(m), heterogeneity=hetero, publication_bias=pb)
+}
+
+# Generate forest plot
+generate_forest_plot <- function(plot_style='classic', confidence_level=0.95){
+  res <- get('.current_result', envir=.GlobalEnv)
+  png('forest_plot.png', width=800, height=600)
+  forest(res, comb.fixed=FALSE, comb.random=TRUE, digits=2)
+  dev.off()
+  'forest_plot.png'
+}
+
+# Assess publication bias with funnel plot
+assess_publication_bias <- function(methods=c('funnel_plot','egger_test')){
+  res <- get('.current_result', envir=.GlobalEnv)
+  out <- list()
+  if('funnel_plot' %in% methods){
+    png('funnel_plot.png', width=800, height=600)
+    funnel(res)
+    dev.off()
+    out$funnel_plot <- 'funnel_plot.png'
+  }
+  if('egger_test' %in% methods){
+    out$egger <- tryCatch(metest(res), error=function(e) NA)
+  }
+  out
+}
+
+# Generate report
+generate_report <- function(format='html', include_code=FALSE){
+  res <- get('.current_result', envir=.GlobalEnv)
+  rmarkdown::render('templates/meta_analysis_report.Rmd',
+                    output_format = switch(format,
+                      html = 'html_document',
+                      pdf = 'pdf_document',
+                      word = 'word_document'),
+                    output_file = paste0('report.',format),
+                    params = list(result=res, include_code=include_code))
+  paste0('report.',format)
+}

--- a/scripts/meta_analysis_utils.R
+++ b/scripts/meta_analysis_utils.R
@@ -45,11 +45,13 @@ perform_analysis <- function(heterogeneity_test=TRUE, publication_bias=TRUE, sen
 }
 
 # Generate forest plot
-generate_forest_plot <- function(plot_style='classic', confidence_level=0.95){
+generate_forest_plot <- function(plot_style='classic', confidence_level=0.95, model='random'){
   res <- get('.current_result', envir=.GlobalEnv)
   temp_file <- tempfile(pattern = "forest_plot", fileext = ".png")
   png(temp_file, width=800, height=600)
-  forest(res, comb.fixed=FALSE, comb.random=TRUE, digits=2)
+  comb.fixed <- model %in% c('fixed', 'both')
+  comb.random <- model %in% c('random', 'both')
+  forest(res, comb.fixed=comb.fixed, comb.random=comb.random, digits=2)
   dev.off()
   temp_file
 }

--- a/scripts/meta_analysis_utils.R
+++ b/scripts/meta_analysis_utils.R
@@ -76,7 +76,10 @@ generate_report <- function(format='html', include_code=FALSE){
                       html = 'html_document',
                       pdf = 'pdf_document',
                       word = 'word_document'),
-                    output_file = paste0('report.',format),
+                    output_file = { 
+                      temp_file <- tempfile(fileext = paste0('.', format))
+                      temp_file
+                    },
                     params = list(result=res, include_code=include_code))
-  paste0('report.',format)
+  temp_file
 }

--- a/scripts/meta_analysis_utils.R
+++ b/scripts/meta_analysis_utils.R
@@ -61,7 +61,7 @@ assess_publication_bias <- function(methods=c('funnel_plot','egger_test')){
     out$funnel_plot <- 'funnel_plot.png'
   }
   if('egger_test' %in% methods){
-    out$egger <- tryCatch(metest(res), error=function(e) NA)
+    out$egger <- tryCatch(ranktest(res), error=function(e) NA)
   }
   out
 }

--- a/scripts/plumber.R
+++ b/scripts/plumber.R
@@ -75,6 +75,9 @@ function(req, data_format = "csv"){
 #* @param sensitivity_analysis logical
 #* @post /perform_meta_analysis
 function(heterogeneity_test = TRUE, publication_bias = TRUE, sensitivity_analysis = FALSE){
+  if (!data_uploaded) {
+    stop("Data has not been uploaded. Please upload data before performing analysis.")
+  }
   res <- perform_analysis(heterogeneity_test, publication_bias, sensitivity_analysis)
   list(status = "analyzed", summary = res$summary)
 }

--- a/scripts/plumber.R
+++ b/scripts/plumber.R
@@ -29,10 +29,38 @@ function(req, data_format = "csv"){
     stop("File size exceeds the 5 MB limit.")
   }
   
-  # Validate content type
-  valid_content_types <- c("text/csv", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-  if (!req$HTTP_CONTENT_TYPE %in% valid_content_types) {
-    stop("Invalid content type. Only CSV and Excel files are allowed.")
+  # Validate content type and file signature
+  valid_content_types <- c(
+    "text/csv",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/octet-stream"
+  )
+  content_type_valid <- req$HTTP_CONTENT_TYPE %in% valid_content_types
+
+  # Check file signature (magic number)
+  is_csv <- function(raw_bytes) {
+    # CSV files are plain text, so we check if the first bytes are printable ASCII or UTF-8 BOM
+    if (length(raw_bytes) >= 3 && all(raw_bytes[1:3] == as.raw(c(0xEF, 0xBB, 0xBF)))) {
+      # UTF-8 BOM present, treat as CSV
+      return(TRUE)
+    }
+    # Check if first 512 bytes are printable or whitespace
+    ascii_check <- all(raw_bytes[1:min(512, length(raw_bytes))] %in% as.raw(c(9, 10, 13, 32:126)))
+    return(ascii_check)
+  }
+
+  is_excel <- function(raw_bytes) {
+    # XLSX files are ZIP archives: first 4 bytes are 50 4B 03 04
+    if (length(raw_bytes) >= 4 && all(raw_bytes[1:4] == as.raw(c(0x50, 0x4B, 0x03, 0x04)))) {
+      return(TRUE)
+    }
+    return(FALSE)
+  }
+
+  file_signature_valid <- is_csv(req$postBody) || is_excel(req$postBody)
+
+  if (!content_type_valid && !file_signature_valid) {
+    stop("Invalid file type. Only CSV and Excel files are allowed.")
   }
   
   tmp <- tempfile(fileext = ifelse(data_format == "excel", ".xlsx", ".csv"))

--- a/scripts/plumber.R
+++ b/scripts/plumber.R
@@ -84,7 +84,23 @@ function(heterogeneity_test = TRUE, publication_bias = TRUE, sensitivity_analysi
 #* @param confidence_level Confidence level
 #* @post /generate_forest_plot
 function(plot_style = "classic", confidence_level = 0.95){
+  # Generate the plot and get the path to the temporary file
   path <- generate_forest_plot(plot_style, confidence_level)
+
+  # Ensure the file exists and is in a secure temp directory
+  if (!file.exists(path) || !grepl(tempdir(), normalizePath(path), fixed = TRUE)) {
+    stop("Invalid or missing plot file.")
+  }
+
+  # Read the file content
+  file_content <- readBin(path, what = "raw", n = file.info(path)$size)
+
+  # Securely delete the file after reading
+  unlink(path)
+
+  # Return the file content as a response with appropriate content type
+  plumber::as_attachment(file_content, filename = basename(path), type = "image/png")
+}
   plumber::include_file(path)
 }
 

--- a/scripts/plumber.R
+++ b/scripts/plumber.R
@@ -63,9 +63,12 @@ function(req, data_format = "csv"){
     stop("Invalid file type. Only CSV and Excel files are allowed.")
   }
   
+  # Validate the file content in memory
+  validated <- validate_data(req$postBody, data_format)
+  
+  # Write the validated content to a temporary file
   tmp <- tempfile(fileext = ifelse(data_format == "excel", ".xlsx", ".csv"))
   writeBin(req$postBody, tmp)
-  validated <- validate_data(tmp, data_format)
   list(status = "uploaded", rows = nrow(validated))
 }
 

--- a/scripts/plumber.R
+++ b/scripts/plumber.R
@@ -23,6 +23,18 @@ function(study_type = NULL, effect_measure = NULL, analysis_model = NULL){
 #* @param data_format Data format: csv, excel, revman
 #* @post /upload_study_data
 function(req, data_format = "csv"){
+  # Set file size limit (e.g., 5 MB)
+  max_file_size <- 5 * 1024 * 1024
+  if (length(req$postBody) > max_file_size) {
+    stop("File size exceeds the 5 MB limit.")
+  }
+  
+  # Validate content type
+  valid_content_types <- c("text/csv", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+  if (!req$HTTP_CONTENT_TYPE %in% valid_content_types) {
+    stop("Invalid content type. Only CSV and Excel files are allowed.")
+  }
+  
   tmp <- tempfile(fileext = ifelse(data_format == "excel", ".xlsx", ".csv"))
   writeBin(req$postBody, tmp)
   validated <- validate_data(tmp, data_format)

--- a/scripts/plumber.R
+++ b/scripts/plumber.R
@@ -1,0 +1,67 @@
+# Load required packages
+library(plumber)
+source('scripts/meta_analysis_utils.R')
+
+#* @apiTitle MCP Meta-Analysis Server
+#* @apiDescription Simple MCP server for running meta-analyses in R
+
+#* Initialize a new meta-analysis session
+#* @param study_type Type of study: clinical_trial, observational, diagnostic
+#* @param effect_measure Effect measure: OR, RR, MD, SMD, HR
+#* @param analysis_model Model type: fixed, random, auto
+#* @post /initialize_meta_analysis
+function(study_type = NULL, effect_measure = NULL, analysis_model = NULL){
+  list(
+    status = "initialized",
+    study_type = study_type,
+    effect_measure = effect_measure,
+    analysis_model = analysis_model
+  )
+}
+
+#* Upload and validate study data (CSV content in request body)
+#* @param data_format Data format: csv, excel, revman
+#* @post /upload_study_data
+function(req, data_format = "csv"){
+  tmp <- tempfile(fileext = ifelse(data_format == "excel", ".xlsx", ".csv"))
+  writeBin(req$postBody, tmp)
+  validated <- validate_data(tmp, data_format)
+  list(status = "uploaded", rows = nrow(validated))
+}
+
+#* Perform meta-analysis
+#* @param heterogeneity_test logical
+#* @param publication_bias logical
+#* @param sensitivity_analysis logical
+#* @post /perform_meta_analysis
+function(heterogeneity_test = TRUE, publication_bias = TRUE, sensitivity_analysis = FALSE){
+  res <- perform_analysis(heterogeneity_test, publication_bias, sensitivity_analysis)
+  list(status = "analyzed", summary = res$summary)
+}
+
+#* Generate forest plot
+#* @param plot_style Plot style: classic, modern, journal_specific
+#* @param confidence_level Confidence level
+#* @post /generate_forest_plot
+function(plot_style = "classic", confidence_level = 0.95){
+  path <- generate_forest_plot(plot_style, confidence_level)
+  plumber::include_file(path)
+}
+
+#* Assess publication bias
+#* @param methods Vector of methods
+#* @post /assess_publication_bias
+function(methods = c("funnel_plot", "egger_test")){
+  bias <- assess_publication_bias(methods)
+  list(status = "done", bias = bias)
+}
+
+#* Generate analysis report
+#* @param format html, pdf or word
+#* @param include_code logical
+#* @post /generate_report
+function(format = "html", include_code = FALSE){
+  report <- generate_report(format, include_code)
+  plumber::include_file(report)
+}
+

--- a/templates/meta_analysis_report.Rmd
+++ b/templates/meta_analysis_report.Rmd
@@ -1,0 +1,29 @@
+---
+title: "Meta-Analysis Report"
+output: html_document
+params:
+  result: NULL
+  include_code: false
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = params$include_code)
+```
+
+# Summary
+
+```{r}
+summary(params$result)
+```
+
+# Forest Plot
+
+```{r, echo=FALSE}
+forest(params$result)
+```
+
+# Funnel Plot
+
+```{r, echo=FALSE}
+funnel(params$result)
+```


### PR DESCRIPTION
## Summary
- implement basic plumber API for MCP meta-analysis features
- add helper functions for analysis, plotting and reporting
- provide an R Markdown template for reports
- supply Dockerfile and README for container setup

## Testing
- `git status --short`
- `Rscript -e "install.packages(c('plumber','meta','metafor','rmarkdown','readxl'))"` *(fails: configuration of packages blocked due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_688ade8f8f408329bd1fbe01efbf5e4d

## Summary by Sourcery

Set up an R-based MCP meta-analysis server by integrating plumber API endpoints, analysis helper functions, report templating, and Docker-based deployment.

New Features:
- Implement MCP meta-analysis HTTP API via plumber with endpoints for session initialization, data upload, analysis execution, plot generation, bias assessment, and report creation.
- Add R utility script with functions for data validation, meta-analysis execution, forest/funnel plotting, publication bias assessment, and automated report rendering.
- Provide an R Markdown template for generating HTML, PDF, or Word meta-analysis reports.
- Containerize the service with a Dockerfile and startup script for easy deployment.

Build:
- Add Dockerfile to install required system libraries and R packages, and define container entrypoint.

Documentation:
- Add README with build, run, and API usage instructions.

Chores:
- Introduce a .gitignore file.